### PR TITLE
fixes problem with the user's name not displaying on the user page

### DIFF
--- a/public/scripts/user.js
+++ b/public/scripts/user.js
@@ -3,7 +3,7 @@ angular.module('user.controllers', [])
   .controller('UserCtrl', function($scope, $http, $stateParams, $localStorage) {
     $http.get('http://localhost:3000/users/' + $localStorage.userID)
       .success(function(data) {
-        $scope.user = data;
+        $scope.user = data.data;
       })
       .error(function(data) { console.log('Error: ' + data); })
     $http.get('http://localhost:3000/admin/users/' + $localStorage.userID + '/recipes')


### PR DESCRIPTION
The response coming back from the api was actually find. The user's information was just nested a little further in the response.
